### PR TITLE
Player Win count

### DIFF
--- a/src/bot/Bot.ts
+++ b/src/bot/Bot.ts
@@ -811,11 +811,19 @@ export default class Bot {
                 if (!sender.CurrentGame.Host)
                     return; 
                     
-                if (game.Ruleset != MultiplayerGameRuleset.Team)
-                    return await Bot.SendMessage(game.GetChatChannelName(), "Teams are not enabled, so you cannot clear the wins.");
+                switch (game.Ruleset) {
+                    case MultiplayerGameRuleset.Team:
+                        game.UpdateTeamWinCount(0, 0);
+                        await Bot.SendMessage(game.GetChatChannelName(), "Team win count has been reset.");
+                        break;
+                    case MultiplayerGameRuleset.Free_For_All:
+                        for (let i = 0; i < game.Players.length; i++)
+                            game.UpdatePlayerWinCount(game.Players[i], 0, false);
 
-                game.UpdateTeamWinCount(0, 0);
-                await Bot.SendMessage(game.GetChatChannelName(), "Team win count has been reset.");
+                        // Inform lobby users at the end to make sure that packet only gets sent once
+                        game.InformLobbyUsers();
+                        break;
+                }
                 break;
             case "teamwins":
                 if (!sender.CurrentGame.Host)

--- a/src/bot/Bot.ts
+++ b/src/bot/Bot.ts
@@ -821,6 +821,7 @@ export default class Bot {
                             game.UpdatePlayerWinCount(game.Players[i], 0, false);
 
                         // Inform lobby users at the end to make sure that packet only gets sent once
+                        await Bot.SendMessage(game.GetChatChannelName(), "All players' win counts have been reset.");
                         game.InformLobbyUsers();
                         break;
                 }

--- a/src/bot/Bot.ts
+++ b/src/bot/Bot.ts
@@ -854,6 +854,33 @@ export default class Bot {
 
                 await Bot.SendMessage(game.GetChatChannelName(), `Team win count changed - Red: ${game.RedTeamWins} | Blue: ${game.BlueTeamWins}`);
                 break;
+            case "playerwins":
+                if (!sender.CurrentGame.Host)
+                    return;
+
+                if (game.Ruleset != MultiplayerGameRuleset.Free_For_All)
+                    return await Bot.SendMessage(game.GetChatChannelName(), "You cannot change player win counts in team mode.");
+
+                if (args.length < 3)
+                    return await Bot.SendMessage(game.GetChatChannelName(), "Incorrect command usage: !playerwins <user_name> <wins>");
+
+                const playerWins = parseInt(args[2]);
+
+                if (isNaN(playerWins) || playerWins < 0 || playerWins > 9999)
+                    return await Bot.SendMessage(game.GetChatChannelName(), "Invalid win count."); 
+                    
+                const playerWinsTargetUsername: string = args[1].replace(/_/g, " ");
+                const playerWinsTarget: User = Albatross.Instance.OnlineUsers.GetUserByUsername(playerWinsTargetUsername);
+
+                if (!playerWinsTarget)
+                    return await Bot.SendMessage(game.GetChatChannelName(), "That user is not online!");
+
+                if (!game.Players.includes(playerWinsTarget))
+                    return await Bot.SendMessage(game.GetChatChannelName(), "That player is not in the game!");
+
+                game.UpdatePlayerWinCount(playerWinsTarget, playerWins);
+                await Bot.SendMessage(game.GetChatChannelName(), `${playerWinsTarget.Username}'s win count has been changed to: ${playerWins}.`);
+                break;
         }
     }
 }

--- a/src/multiplayer/MultiplayerPlayerWins.ts
+++ b/src/multiplayer/MultiplayerPlayerWins.ts
@@ -1,0 +1,16 @@
+import { JsonObject, JsonProperty } from "json2typescript";
+import User from "../sessions/User";
+
+@JsonObject("MultiplayerPlayerWins")
+export default class MultiplayerPlayerWins { 
+    @JsonProperty("u")
+    public Id: number;
+
+    @JsonProperty("w")
+    public Wins: number;
+
+    constructor(user: User, wins: number = 0) {
+        this.Id = user.Id;
+        this.Wins = wins;
+    }
+}

--- a/src/packets/PacketId.ts
+++ b/src/packets/PacketId.ts
@@ -79,7 +79,8 @@ enum PacketId {
     ServerGameLongNotePercentageChanged,
     ServerGameMaxPlayersChanged,
     ServerGameMinimumRateChanged,
-    ServerGameTeamWinCount
+    ServerGameTeamWinCount,
+    ServerGamePlayerWinCount
 }
 
 export default PacketId;

--- a/src/packets/server/ServerPacketGamePlayerWinCount.ts
+++ b/src/packets/server/ServerPacketGamePlayerWinCount.ts
@@ -1,0 +1,21 @@
+import Packet from "../Packet";
+import { JsonObject, JsonProperty } from "json2typescript";
+import PacketId from "../PacketId";
+import MultiplayerPlayerWins from "../../multiplayer/MultiplayerPlayerWins";
+
+@JsonObject("ServerPacketGamePlayerWinCount")
+export default class ServerPacketGamePlayerWinCount extends Packet {
+    public Id: PacketId = PacketId.ServerGamePlayerWinCount;
+
+    @JsonProperty("u")
+    public UserId: number;
+
+    @JsonProperty("w")
+    public Wins: number;
+
+    constructor(wins: MultiplayerPlayerWins) {
+        super();
+        this.UserId = wins.Id;
+        this.Wins = wins.Wins;
+    }
+}

--- a/src/sessions/User.ts
+++ b/src/sessions/User.ts
@@ -39,6 +39,7 @@ import ServerPacketGameJudgements from "../packets/server/ServerPacketGameJudgem
 import ServerPacketAllPlayersLoaded from "../packets/server/ServerPacketAllPlayersLoaded";
 import MultiplayerPlayerMods from "../multiplayer/MultiplayerPlayerMods";
 import MultiplayerGameRuleset from "../multiplayer/MultiplayerGameRuleset";
+import MultiplayerPlayerWins from "../multiplayer/MultiplayerPlayerWins";
 
 export default class User implements IPacketWritable, IStringifyable {
     /**
@@ -392,7 +393,9 @@ export default class User implements IPacketWritable, IStringifyable {
         game.Players.push(this);
         game.PlayerIds.push(this.Id);
         game.PlayerMods.push(new MultiplayerPlayerMods(this, "0"));
-
+        
+        if (!game.PlayerWins.find(x => x.Id == this.Id))
+            game.PlayerWins.push(new MultiplayerPlayerWins(this));
 
         this.JoinChatChannel(ChatManager.Channels[`#multiplayer_${game.Id}`]);
 


### PR DESCRIPTION
* Keeps track of how many wins each individual player has
* !clearwins works with the free-for-all ruleset
* Adds a !playerwins command to set the win count for individual players
* Caches each player's win count in Redis.